### PR TITLE
Fixed Xcode 14.3 issue

### DIFF
--- a/catch/catch.hpp
+++ b/catch/catch.hpp
@@ -6472,10 +6472,11 @@ namespace Catch {
 #endif
         template<typename V>
         static void shuffle( V& vector ) {
-            RandomNumberGenerator rng;
+
 #ifdef CATCH_CPP14_OR_GREATER
-            std::shuffle( vector.begin(), vector.end(), rng );
+            std::shuffle( vector.begin(), vector.end(), std::default_random_engine{std::random_device{}()} );
 #else
+            RandomNumberGenerator rng;
             std::random_shuffle( vector.begin(), vector.end(), rng );
 #endif
         }


### PR DESCRIPTION
Fixed issue - "Static_assert failed due to requirement '__libcpp_random_is_valid_urng<Catch::RandomNumberGenerator, void>::value' """, because of C++ Standard Library deprecations in Xcode 14.3